### PR TITLE
The balance miners deserve but do not want

### DIFF
--- a/code/modules/clothing/spacesuits/miscellaneous.dm
+++ b/code/modules/clothing/spacesuits/miscellaneous.dm
@@ -248,6 +248,25 @@ Contains:
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/ert/jani
 	allowed = list(/obj/item/storage/bag/trash, /obj/item/melee/flyswatter, /obj/item/mop, /obj/item/holosign_creator, /obj/item/reagent_containers/glass/bucket, /obj/item/reagent_containers/spray/chemsprayer/janitor)
 
+/obj/item/clothing/suit/space/hardsuit/ert/berserker
+	name = "champion's hardsuit"
+	desc = "Voices echo from the hardsuit, driving the user insane."
+	icon_state = "hardsuit-berserker"
+	item_state = "hardsuit-berserker"
+	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/ert/berserker
+	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
+	resistance_flags = FIRE_PROOF
+
+/obj/item/clothing/head/helmet/space/hardsuit/ert/berserker
+	name = "champion's helmet"
+	desc = "Peering into the eyes of the helmet is enough to seal damnation."
+	icon_state = "hardsuit0-berserker"
+	item_state = "hardsuit0-berserker"
+	hardsuit_type = "berserker"
+	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
+	actions_types = list()
+	resistance_flags = FIRE_PROOF
+
 /obj/item/clothing/suit/space/eva
 	name = "EVA suit"
 	icon_state = "space"
@@ -358,20 +377,6 @@ Contains:
 	icon_state = "hardsuit0-inq"
 	item_state = "hardsuit0-inq"
 	hardsuit_type = "inq"
-
-/obj/item/clothing/suit/space/hardsuit/ert/paranormal/berserker
-	name = "champion's hardsuit"
-	desc = "Voices echo from the hardsuit, driving the user insane."
-	icon_state = "hardsuit-berserker"
-	item_state = "hardsuit-berserker"
-	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/ert/paranormal/berserker
-
-/obj/item/clothing/head/helmet/space/hardsuit/ert/paranormal/berserker
-	name = "champion's helmet"
-	desc = "Peering into the eyes of the helmet is enough to seal damnation."
-	icon_state = "hardsuit0-berserker"
-	item_state = "hardsuit0-berserker"
-	hardsuit_type = "berserker"
 
 /obj/item/clothing/head/helmet/space/fragile
 	name = "emergency space helmet"

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -984,7 +984,6 @@
 	switch(loot)
 		if(1)
 			new /obj/item/mayhem(src)
-			new /obj/item/gun/magic/staff/spellblade(src)
 		if(2)
 			new /obj/item/blood_contract(src)
 			new /obj/item/gun/magic/staff/spellblade(src)

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -13,7 +13,7 @@
 	desc = "It's watching you suspiciously."
 
 /obj/structure/closet/crate/necropolis/tendril/PopulateContents()
-	var/loot = rand(1,28)
+	var/loot = rand(1,26)
 	switch(loot)
 		if(1)
 			new /obj/item/shared_storage/red(src)
@@ -41,44 +41,39 @@
 		if(11)
 			new /obj/item/ship_in_a_bottle(src)
 		if(12)
-			new /obj/item/clothing/suit/space/hardsuit/ert/paranormal/berserker(src)
+			new /obj/item/clothing/suit/space/hardsuit/ert/berserker(src)
 		if(13)
 			new /obj/item/jacobs_ladder(src)
 		if(14)
-			new /obj/item/nullrod/scythe/talking(src)
-		if(15)
-			new /obj/item/nullrod/armblade(src)
-		if(16)
 			new /obj/item/guardiancreator(src)
-		if(17)
+		if(15)
 			if(prob(50))
 				new /obj/item/disk/design_disk/modkit_disc/mob_and_turf_aoe(src)
 			else
 				new /obj/item/disk/design_disk/modkit_disc/bounty(src)
-		if(18)
+		if(16)
 			new /obj/item/warp_cube/red(src)
-		if(19)
+		if(17)
 			new /obj/item/wisp_lantern(src)
-		if(20)
+		if(18)
 			new /obj/item/immortality_talisman(src)
-		if(21)
+		if(19)
 			new /obj/item/gun/magic/hook(src)
-		if(22)
+		if(20)
 			new /obj/item/voodoo(src)
-		if(23)
+		if(21)
 			new /obj/item/grenade/clusterbuster/inferno(src)
-		if(24)
-			new /obj/item/reagent_containers/food/drinks/bottle/holywater/hell(src)
-			new /obj/item/clothing/suit/space/hardsuit/ert/paranormal/inquisitor(src)
-		if(25)
+		if(22)
 			new /obj/item/book/granter/spell/summonitem(src)
-		if(26)
+		if(23)
 			new /obj/item/book_of_babel(src)
-		if(27)
+		if(24)
 			new /obj/item/borg/upgrade/modkit/lifesteal(src)
 			new /obj/item/bedsheet/cult(src)
-		if(28)
+		if(25)
 			new /obj/item/clothing/neck/necklace/memento_mori(src)
+		if(26)
+			new /obj/item/clothing/suit/space/hardsuit/ert/berserker(src)
 
 //KA modkit design discs
 /obj/item/disk/design_disk/modkit_disc
@@ -415,7 +410,8 @@
 	armour_penetration = 100
 	damage_type = BRUTE
 	hitsound = 'sound/effects/splat.ogg'
-	paralyze = 30
+	knockdown = 30
+	paralyze = 10
 	var/chain
 
 /obj/projectile/hook/fire(setAngle)
@@ -452,7 +448,8 @@
 
 /obj/projectile/hook/bounty
 	damage = 0
-	paralyze = 20
+	knockdown = 20
+	paralyze = 0
 
 //Immortality Talisman
 /obj/item/immortality_talisman
@@ -466,7 +463,6 @@
 
 /obj/item/immortality_talisman/Initialize()
 	. = ..()
-	AddComponent(/datum/component/anti_magic, TRUE, TRUE, TRUE)
 
 /datum/action/item_action/immortality
 	name = "Immortality"
@@ -749,16 +745,14 @@
 	name = "dragon chest"
 
 /obj/structure/closet/crate/necropolis/dragon/PopulateContents()
-	var/loot = rand(1,4)
+	var/loot = rand(1,3)
 	switch(loot)
 		if(1)
 			new /obj/item/melee/ghost_sword(src)
 		if(2)
 			new /obj/item/lava_staff(src)
-		if(3)
 			new /obj/item/book/granter/spell/sacredflame(src)
-			new /obj/item/gun/magic/wand/fireball(src)
-		if(4)
+		if(3)
 			new /obj/item/dragons_blood(src)
 
 /obj/structure/closet/crate/necropolis/dragon/crusher
@@ -778,7 +772,7 @@
 	flags_1 = CONDUCT_1
 	sharpness = IS_SHARP
 	w_class = WEIGHT_CLASS_BULKY
-	force = 1
+	force = 20
 	throwforce = 1
 	hitsound = 'sound/effects/ghost2.ogg'
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "rended")
@@ -846,16 +840,16 @@
 	return ghost_counter
 
 /obj/item/melee/ghost_sword/attack(mob/living/target, mob/living/carbon/human/user)
-	force = 0
+	force = 20
 	var/ghost_counter = ghost_check()
 
-	force = CLAMP((ghost_counter * 4), 0, 75)
+	force = CLAMP((ghost_counter * 4 + 20), 0, 75)
 	user.visible_message("<span class='danger'>[user] strikes with the force of [ghost_counter] vengeful spirits!</span>")
 	..()
 
 /obj/item/melee/ghost_sword/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
 	var/ghost_counter = ghost_check()
-	final_block_chance += CLAMP((ghost_counter * 5), 0, 75)
+	final_block_chance += CLAMP((ghost_counter * 5 + 30), 0, 75)
 	owner.visible_message("<span class='danger'>[owner] is protected by a ring of [ghost_counter] ghosts!</span>")
 	return ..()
 
@@ -933,7 +927,7 @@
 	var/reset_turf_type = /turf/open/floor/plating/asteroid/basalt
 	var/reset_string = "basalt"
 	var/create_cooldown = 100
-	var/create_delay = 30
+	var/create_delay = 15
 	var/reset_cooldown = 50
 	var/timer = 0
 	var/static/list/banned_turfs = typecacheof(list(/turf/open/space/transit, /turf/closed))
@@ -986,13 +980,13 @@
 /obj/structure/closet/crate/necropolis/bubblegum/PopulateContents()
 	new /obj/item/clothing/suit/space/hostile_environment(src)
 	new /obj/item/clothing/head/helmet/space/hostile_environment(src)
-	var/loot = rand(1,3)
+	var/loot = rand(1,2)
 	switch(loot)
 		if(1)
 			new /obj/item/mayhem(src)
+			new /obj/item/gun/magic/staff/spellblade(src)
 		if(2)
 			new /obj/item/blood_contract(src)
-		if(3)
 			new /obj/item/gun/magic/staff/spellblade(src)
 
 /obj/structure/closet/crate/necropolis/bubblegum/crusher

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
@@ -351,7 +351,7 @@
 			head = /obj/item/clothing/head/helmet/knight
 			suit = /obj/item/clothing/suit/armor/riot/knight
 			back = /obj/item/shield/riot/buckler
-			belt = /obj/item/nullrod/claymore
+			belt = /obj/item/claymore
 			r_pocket = /obj/item/tank/internals/emergency_oxygen
 			mask = /obj/item/clothing/mask/breath
 		if("Operative")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes all lavaland loot that grants immunity to magic
Removes fireball wand
Buffs other ash drake rewards
Buffs bubblegum rewards


**Tendrils :**

- Talking sword and dark blessing armblade removed

- Inquisitor hardsuit replaced with another roll for champion's hardsuit

- Champion's hardsuit anti-magic component removed

- Immortality Talisman anti-magic component removed

- Crusader legion now drops a regular claymore rather than the chaplain's nullrod

- Meat hook stun converted to knockdown


**Megafauna :**
- Removed fireball wand ( drake now only has 3 possible rewards )
1. Lava staff + Book of flames
2. Spectral Blade
3. Bottle of dragon's blood

- Lowered casting time of lava staff from 30 to 15

- Spectral blade now has 20 base force and 30% base block chance

- Bubblegum now only has 2 possible rewards
1. Spellblade + Blood contract
2. Mayhem in a bottle


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Lavaland shouldn't create powerful chapalains based on rng.
Tendrils are the easiest loot to acquire but also potentially the strongest if used correctly.
There are usually always more Tendrils than Megafauna and to say the odds to get something good from them are better would be an understatement.
I lost track of how many cults and wizards I have stopped in the past with little to no effort because of this.
Most people don't expect miners to be immune to magic and we usually have better armour and weapons than the average chaplain too.

Fireball wand is almost a free kill for every charge you got in it ( up to 8 per )
The difficulty of the ash drake fight doesn't justifty that at all, the other drops are weak not to say absolutely garbage in comparison.
Rarely have I seen spectral blade used to actually kill people, the very few cases I saw someone use it was AFTER murderboning just to show off.
Lava staff has a decent melee but the spell is a gimmick only used to cross lava lakes and open locked stuff relatively fast.
Removing the free instantkill for buffs in the more skill based weapons named above should make for more interesting gameplay rather than point, click and win

Bubblegum, only one can spawn at a time and he is alot harder to kill than any other megafauna.
Probably the worst reward for the risk you have to take.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Removed all sources of ANTI_MAGIC from lavaland
del: Removed fireball wand from the ash drake chest
tweak: Bubblegum rewards improved
balance: Spectral blade now has a base force of 20 and 30% block chance
balance: Halved the lava staff's cast time
fix: Meat hook stun shortened, replaced with knockdown
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
